### PR TITLE
Add cpuinfo dump using cpuid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ EMUARGS += -hda toyos-disk.img -k en-us
 EMUARGS += -rtc base=localtime -net nic,model=rtl8139 -net user
 EMUARGS += -net dump -no-kvm-irqchip
 EMUARGS += $(BOOT_MODULES_X)
-EMUKVM   = -enable-kvm
+EMUKVM   = -enable-kvm -cpu host
 
 DISK_ROOT = root=/dev/hda
 VID_QEMU  = vid=qemu,,1280,,720

--- a/kernel/cpu/cpuinfo.c
+++ b/kernel/cpu/cpuinfo.c
@@ -1,0 +1,126 @@
+/*
+ * This file is part of ToyOS and is released under the terms
+ * of the NCSA / University of Illinois License - see LICENSE.md
+ * Copyright (C) 2016 Fabien Siron <fabien.siron@epita.fr>
+ *
+ * cpuinfo
+ *
+ * Extract cpuinfo
+ */
+
+#include <system.h>
+#include <cpuinfo.h>
+
+const char *feature_names[] = {
+	"fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8",
+	"apic", "", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse-36",
+	"psn", "clfsh", "", "ds", "acpi", "mmx", "fxsr", "sse", "sse2",
+	"ss", "htt", "tm", "ia64", "pbe", "sse3", "pclmulqdq", "dtes64",
+	"monitor", "ds-cpl", "vmx", "smx", "est", "tm2", "ssse3", "cnxt-id",
+	"sdbg", "fma", "cx16", "xtpr", "pdcm", "", "pcid", "dca", "sse4.1",
+	"sse4.2", "x2apic", "movbe", "popcnt", "tsc-deadline", "aes",
+	"xsave", "osxsave", "avx", "f17c", "rdrnd", "hypervisor"
+};
+
+static inline void
+cpuid(unsigned int *eax, unsigned int *ebx,
+      unsigned int *ecx, unsigned int *edx) {
+	__asm__ __volatile__("cpuid"
+			     : "=a" (*eax), "=b" (*ebx),
+			       "=c" (*ecx), "=d" (*edx)
+			     : "a" (*eax), "c"(0));
+}
+
+static void
+get_cpu_vendor(void) {
+	unsigned int a = 0x00000000;
+	cpuid(&a,
+	      (unsigned int *)&cpu_info.vendor[0],
+	      (unsigned int *)&cpu_info.vendor[8],
+	      (unsigned int *)&cpu_info.vendor[4]);
+}
+
+static void
+get_cpu_cap(void) {
+	unsigned int a = 0x00000001;
+	unsigned int b,c,d, i = 0;
+	char *it;
+	cpuid(&a,(unsigned int *)&b, (unsigned int *)&c,
+	      (unsigned int *)&d);
+
+	for (i = 0, it = cpu_info.cap; i < 61 ;i++) {
+		if (i < 32 && (d & (0x1 << i))) {
+			size_t len = strlen(feature_names[i]);
+			strcpy(it, feature_names[i]);
+			it += len;
+			*it = ' ';
+			it++;
+		} else if (i >= 32 && (c & ( 0x1 << (i-32)))) {
+			size_t len = strlen(feature_names[i]);
+			strcpy(it, feature_names[i]);
+			it += len;
+			*it = ' ';
+			it++;
+		}
+	}
+	*it = '\0';
+}
+
+static void
+get_cpu_fms(void) {
+	/* fms: family, model, stepping (intel application note 485) */
+	unsigned int a = 0x00000001;
+	unsigned int b,c,d;
+	cpuid(&a,(unsigned int *)&b, (unsigned int *)&c,
+	      (unsigned int *)&d);
+
+	cpu_info.family_value = ((a >> 20) & 0xf) + ((a >> 8) & 0x7);
+	cpu_info.model_value = (((a >> 16) & 0x7) << 4) + ((a >> 4) & 0x7);
+	cpu_info.stepping_value = a & 0x7;
+}
+
+extern unsigned int cpuid_extended_check(void);
+
+static void
+get_cpu_model_name(void) {
+	unsigned int a, a_;
+	unsigned int b,c,d,i;
+	char *it = cpu_info.model_name;
+	if (!cpuid_extended_check()) {
+		cpu_info.model_name[0] = '?';
+		cpu_info.model_name[1] = '\0';
+		return;
+	}
+
+	a_ = 0x80000002;
+	for(a= a_, i = 0; i < 3; ++i, a = a_ + i) {
+		cpuid(&a,(unsigned int *)&b, (unsigned int *)&c,
+		      (unsigned int *)&d);
+
+		memcpy(it, &a, sizeof(unsigned int));
+		it += 4;
+		memcpy(it, &b, sizeof(unsigned int));
+		it += 4;
+		memcpy(it, &c, sizeof(unsigned int));
+		it += 4;
+		memcpy(it, &d, sizeof(unsigned int));
+		it += 4;
+	}
+
+}
+
+extern unsigned int cpuid_check(void);
+
+unsigned int cpuinfo_dump(void) {
+	memset (&cpu_info, 0, sizeof(struct cpu_info));
+
+	if (!cpuid_check())
+		return -1;
+
+	get_cpu_vendor();
+	get_cpu_cap();
+	get_cpu_fms();
+	get_cpu_model_name();
+
+	return 0;
+}

--- a/kernel/cpuid_check.S
+++ b/kernel/cpuid_check.S
@@ -1,0 +1,40 @@
+//  Basically, we try to change id bit, if it remains the same, cpu
+//  does not support cpuid instruction.
+//
+//  @ret: 0, cpu does not have cpuid, otherwise, it's okay.
+
+
+.section .text
+.align 4
+
+.set id, 0x00200000
+
+.global cpuid_check
+.type cpuid_check, @function
+
+cpuid_check:
+	pushf
+	pushf
+	xorl $id,(%esp)
+	popf
+	pushf
+	pop %eax
+	xor (%esp),%eax
+	popf
+	andl $id,%eax
+	ret
+
+.global cpuid_extended_check
+.type cpuid_extended_check, @function
+
+cpuid_extended_check:
+	movl $0x80000000, %eax
+	cpuid
+	cmpl $0x80000004, %eax
+	jl fail
+	movl $1, %eax
+	ret
+fail:
+	movl $0, %eax
+	ret
+

--- a/kernel/include/cpuinfo.h
+++ b/kernel/include/cpuinfo.h
@@ -1,0 +1,19 @@
+#ifndef _CPUINFO_H_
+# define _CPUINFO_H_
+
+# include <bitset.h>
+
+struct cpu_info {
+	char vendor[13];
+	char cap[512];
+	unsigned int family_value;
+	unsigned int model_value;
+	unsigned int stepping_value;
+	char model_name[80];
+} cpu_info;
+
+extern const char *feature_names[];
+
+extern unsigned int cpuinfo_dump(void);
+
+#endif /*!_CPUINFO_H_*/

--- a/kernel/main.c
+++ b/kernel/main.c
@@ -47,6 +47,7 @@
 #include <process.h>
 #include <shm.h>
 #include <args.h>
+#include <cpuinfo.h>
 #include <module.h>
 
 uintptr_t initial_esp = 0;
@@ -91,6 +92,7 @@ int kmain(struct multiboot *mboot, uint32_t mboot_mag, uintptr_t esp) {
 	debug_print(NOTICE, "Processing Multiboot information.");
 
 	/* Initialize core modules */
+	cpuinfo_dump();     /* Extract cpuinfo */
 	gdt_install();      /* Global descriptor table */
 	idt_install();      /* IDT */
 	isrs_install();     /* Interrupt service requests */

--- a/modules/procfs.c
+++ b/modules/procfs.c
@@ -10,6 +10,7 @@
 #include <process.h>
 #include <printf.h>
 #include <module.h>
+#include <cpuinfo.h>
 
 #define PROCFS_STANDARD_ENTRIES (sizeof(std_entries) / sizeof(struct procfs_entry))
 #define PROCFS_PROCDIR_ENTRIES  (sizeof(procdir_entries) / sizeof(struct procfs_entry))
@@ -195,7 +196,24 @@ static fs_node_t * procfs_procdir_create(pid_t pid) {
 }
 
 static uint32_t cpuinfo_func(fs_node_t *node, uint32_t offset, uint32_t size, uint8_t *buffer) {
-	return 0;
+	char buf[1024];
+	sprintf(buf, "processor\t: 0\n"
+		"vendor_id\t: %s\n"
+		"cpu_family\t: %d\n"
+		"model\t\t: %d\n"
+		"model name\t: %s\n"
+		"stepping\t: %d\n"
+		"flags\t\t: %s\n",
+		cpu_info.vendor, cpu_info.family_value,
+		cpu_info.model_value, cpu_info.model_name,
+		cpu_info.stepping_value, cpu_info.cap);
+
+	size_t _bsize = strlen(buf);
+	if (offset > _bsize) return 0;
+	if (size > _bsize - offset) size = _bsize - offset;
+
+	memcpy(buffer, buf, size);
+	return size;
 }
 
 static uint32_t meminfo_func(fs_node_t *node, uint32_t offset, uint32_t size, uint8_t *buffer) {


### PR DESCRIPTION
This feature can be very useful for several things:

* First, it's almost mandatory if we want to implement further funny kernel features (64 bits, smp ...)
* It can also be useful if we want to run the kernel on old hardware.
* It allows cat ``/proc/cpuinfo`` for debug/info purpose.

