### PR TITLE
Add libupkg and pkg_info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,12 @@ USER_CXXFLAGS = -O3 -m32 -Wa,--32 -g -Iuserspace
 USER_BINFLAGS =
 
 # Userspace binaries and libraries
-USER_CFILES   = $(shell find userspace -not -wholename '*/lib/*' -name '*.c')
-USER_CXXFILES = $(shell find userspace -not -wholename '*/lib/*' -name '*.c++')
+USER_CFILES   = $(shell find userspace -not -wholename '*/lib/*' \
+-not -wholename '*/libupkg/*' -name '*.c')
+USER_CXXFILES = $(shell find userspace -not -wholename '*/lib/*' \
+-name '*.c++')
 USER_LIBFILES = $(shell find userspace -wholename '*/lib/*' -name '*.c')
+USER_LIBFILES += $(shell find userspace -wholename '*/libupkg/*' -name '*.c')
 
 # Userspace output files (so we can define metatargets)
 USERSPACE  = $(foreach file,$(USER_CFILES),$(patsubst %.c,hdd/bin/%,$(notdir ${file})))
@@ -59,6 +62,7 @@ USERSPACE += $(foreach file,$(USER_CXXFILES),$(patsubst %.c++,hdd/bin/%,$(notdir
 USERSPACE += $(foreach file,$(USER_LIBFILES),$(patsubst %.c,%.o,${file}))
 
 CORE_LIBS = $(patsubst %.c,%.o,$(wildcard userspace/lib/*.c))
+CORE_LIBS = $(patsubst %.c,%.o,$(wildcard userspace/libupkg/*.c))
 
 # Pretty output utilities.
 BEG = util/mk-beg
@@ -268,7 +272,7 @@ hdd/usr/lib/libtoyos.a: ${CORE_LIBS}
 toyos-disk.img: ${USERSPACE} util/devtable
 	@${BEG} "hdd" "Generating a Hard Disk image..."
 	@-rm -f toyos-disk.img
-	@${GENEXT} -B 4096 -d hdd -D util/devtable -U -b ${DISK_SIZE} -N 6144 toyos-disk.img ${ERRORS}
+	@${GENEXT} -B 4096 -d hdd -D util/devtable -U -b ${DISK_SIZE} -N 8192 toyos-disk.img ${ERRORS}
 	@${END} "hdd" "Generated Hard Disk image"
 	@${INFO} "--" "Hard disk image is ready!"
 

--- a/hdd/usr/pkg/pkg_delete-0.1/+CONTENTS
+++ b/hdd/usr/pkg/pkg_delete-0.1/+CONTENTS
@@ -1,0 +1,5 @@
+@name pkg_delete
+@author Fabien Siron <fabien.siron@epita.fr>
+@internal
+@version 0.1
+/bin/pkg_delete

--- a/hdd/usr/pkg/pkg_delete-0.1/+DESC
+++ b/hdd/usr/pkg/pkg_delete-0.1/+DESC
@@ -1,0 +1,4 @@
+pkg_delete is the delete util of the upkg tool suite.
+
+It's basically just a front-end of the libupkg which is a mini bsd-like
+package manager library.

--- a/hdd/usr/pkg/pkg_info-0.1/+CONTENTS
+++ b/hdd/usr/pkg/pkg_info-0.1/+CONTENTS
@@ -1,0 +1,5 @@
+@name pkg_info
+@author Fabien Siron <fabien.siron@epita.fr>
+@internal
+@version 0.1
+/bin/pkg_info

--- a/hdd/usr/pkg/pkg_info-0.1/+DESC
+++ b/hdd/usr/pkg/pkg_info-0.1/+DESC
@@ -1,0 +1,4 @@
+pkg_info is the info util of the upkg tool suite.
+
+It's basically just a front-end of the libupkg which is a mini bsd-like
+package manager library.

--- a/hdd/var/db/upkg/pkg_delete-0.1/+CONTENTS
+++ b/hdd/var/db/upkg/pkg_delete-0.1/+CONTENTS
@@ -1,0 +1,5 @@
+@name pkg_delete
+@author Fabien Siron <fabien.siron@epita.fr>
+@internal
+@version 0.1
+/bin/pkg_delete

--- a/hdd/var/db/upkg/pkg_delete-0.1/+DESC
+++ b/hdd/var/db/upkg/pkg_delete-0.1/+DESC
@@ -1,0 +1,4 @@
+pkg_delete is the delete util of the upkg tool suite.
+
+It's basically just a front-end of the libupkg which is a mini bsd-like
+package manager library.

--- a/hdd/var/db/upkg/pkg_info-0.1/+CONTENTS
+++ b/hdd/var/db/upkg/pkg_info-0.1/+CONTENTS
@@ -1,0 +1,5 @@
+@name pkg_info
+@author Fabien Siron <fabien.siron@epita.fr>
+@internal
+@version 0.1
+/bin/pkg_info

--- a/hdd/var/db/upkg/pkg_info-0.1/+DESC
+++ b/hdd/var/db/upkg/pkg_info-0.1/+DESC
@@ -1,0 +1,4 @@
+pkg_info is the info util of the upkg tool suite.
+
+It's basically just a front-end of the libupkg which is a mini bsd-like
+package manager library.

--- a/userspace/core/pkg_info.c
+++ b/userspace/core/pkg_info.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include "libupkg/libupkg.h"
+#include "libupkg/upkg_plist.h"
+#include "libupkg/upkg_config.h"
+#include "libupkg/upkg_db.h"
+
+/* TODO */
+/* XXX Add some meta */
+/* XXX Factorize code */
+/* XXX Add one line description */
+
+char *__progname;
+
+void
+print_plist(struct upkg *pkg) {
+	struct upkg_plist_elt *node;
+	char *path;
+
+	foreach_in_plist(node, (&pkg->plist)) {
+		path = node->path;
+		printf("\t%s\n", path);
+	}
+}
+
+int
+info_each_packages(struct upkg_db *db, int Aflag, int Dflag, int Mflag) {
+	struct upkg_repo_list *node;
+	struct upkg *upkg;
+	int r = 0;
+
+	if (!Aflag)
+		Aflag = 1;
+
+	foreach_upkg(node, (&db->repos)) {
+		upkg = &node->repo;
+
+		if (upkg_dump(upkg) != -1) {
+			if ((upkg->internal && Aflag == 2) ||
+				!upkg->internal) {
+				printf("%s\n", upkg->name);
+				if (Dflag) {
+					printf("    Description:\n");
+					printf("\t%s\n",
+					       upkg->description);
+				}
+				if (Mflag) {
+					printf("    Author:\n");
+					printf("\t%s\n", upkg->author);
+					printf("    Version:\n");
+					printf("\t%s\n", upkg->version);
+				}
+			}
+		} else {
+			r = -1;
+		}
+	}
+
+	fflush(stdout);
+
+	return r;
+}
+
+int
+info_listed_packages(struct upkg_db *db, int argc, char *argv[],
+		     int Dflag, int Lflag, int Mflag) {
+	int i, r;
+	struct upkg *upkg = malloc (sizeof(struct upkg));
+
+	for (i = 0, r = 0; i < argc; ++i) {
+		if(upkg_db_request(UPKG_DB_GET, db,
+				   upkg, argv[i])) {
+			printf("%s\n", argv[i]);
+			if (upkg_dump(upkg) != -1) {
+				if (Dflag) {
+					printf("    Description:\n");
+					printf("\t%s\n",
+					       upkg->description);
+				}
+				if (Mflag) {
+					printf("    Author:\n");
+					printf("\t%s\n", upkg->author);
+					printf("    Version:\n");
+					printf("\t%s\n", upkg->version);
+				}
+				if (Lflag) {
+					printf("    PList:\n");
+					print_plist(upkg);
+				}
+			} else {
+				printf("    Dump fail !\n");
+				r = -1;
+			}
+		}
+	}
+
+	fflush(stdout);
+
+	return r;
+}
+
+int
+info_exist_packages(struct upkg_db *db, int argc, char *argv[]) {
+	int i, r;
+
+	for (i = 0, r = 0; i < argc; ++i) {
+		if (upkg_db_request(UPKG_DB_EXIST, db, argv[i])) {
+			printf("Found %s!\n", argv[i]);
+		} else {
+			printf("%s not found !\n", argv[i]);
+			r = -1;
+		}
+	}
+
+	fflush(stdout);
+
+	return r;
+}
+
+void
+usage(void) {
+	fprintf(stderr, "usage: %s [-AacdELfm] [package(s)]\n", __progname);
+	exit(1);
+}
+
+int
+main(int argc, char *argv[]) {
+	int c, r;
+	int AFlag = 0;
+	int DFlag = 0, EFlag = 0;
+	int LFlag = 0, MFlag = 0;
+
+	__progname = argv[0];
+
+	while((c = getopt(argc, argv, "AacdELm")) != -1) {
+		switch(c) {
+		case 'A':
+			AFlag = 2;
+			break;
+		case 'a':
+			AFlag = 1;
+			break;
+		case 'c':
+			DFlag = 1;
+			break;
+		case 'd':
+			DFlag = 2;
+			break;
+		case 'E':
+			EFlag = 1;
+			break;
+		case 'L':
+			LFlag = 1;
+			break;
+		case 'm':
+			MFlag = 1;
+			break;
+		default:
+			usage();
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	/* test zone */
+	if ((argc == 0 && LFlag) || (argc == 0 && EFlag)) {
+		fprintf(stderr, "Error: you cannot use this flag without packages in arguments...\n");
+		usage();
+	}
+
+	if (argc && AFlag) {
+		fprintf(stderr, "Error: you cannot use this flag with packages in arguments...\n");
+		usage();
+	}
+
+	if (!upkg_check()) {
+		fprintf(stderr, "Error: you don't have the right permissions.\n");
+		exit(1);
+	}
+
+/*	if (upkg_db_lock()) {
+		fprintf(stderr, "Error: database is already locked\n");
+		exit(1);
+		}*/
+
+	struct upkg_db *upkg_db = upkg_db_get_empty();
+
+	upkg_db_open(upkg_db);
+
+	if (EFlag) {
+		r = info_exist_packages(upkg_db, argc, argv);
+	} else if (argc != 0) {
+		r = info_listed_packages(upkg_db, argc, argv, DFlag,
+					 LFlag, MFlag);
+	} else {
+		r = info_each_packages(upkg_db, AFlag, DFlag, MFlag);
+	}
+
+	upkg_db_release(upkg_db);
+
+/*	upkg_db_unlock();*/
+
+	return r;
+}

--- a/userspace/libupkg/libupkg.h
+++ b/userspace/libupkg/libupkg.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#ifndef _LIBUPKG_H_
+# define _LIBUPKG_H_
+
+# include "libupkg/upkg_config.h"
+
+typedef unsigned char bool;
+
+struct upkg_plist_elt {
+	char path[80];
+	struct upkg_plist_elt *next;
+};
+
+struct upkg {
+	bool internal;
+	char name[80];
+	char path[80];
+	char author[80];
+	char version[80];
+	char description[80 * 25];
+	struct upkg_plist_elt plist;
+};
+
+struct upkg_repo_list {
+	struct upkg repo;
+	struct upkg_repo_list *next;
+};
+
+# define foreach_upkg(repo, repos)					\
+	for (repo = repos->next;					\
+	     repo != NULL;						\
+	     repo = repo->next)
+
+int upkg_dump(struct upkg *);
+void upkg_free(struct upkg *);
+
+# define foreach_in_plist(p, plist)		\
+	for (p = plist->next;			\
+	     p != NULL;				\
+	     p = p->next)
+
+int upkg_delete(struct upkg *);
+
+
+#endif /*_LIBUPKG_H_*/

--- a/userspace/libupkg/upkg.c
+++ b/userspace/libupkg/upkg.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "libupkg/upkg_plist.h"
+#include "libupkg/libupkg.h"
+
+enum upkg_info_const {
+	CONTENTS = 0,
+	DESC,
+	/* XXX not implemented yet */
+	REQUIRING,
+	REQUIRED_BY
+};
+
+char *upkg_info[] = {
+	[CONTENTS] = "+CONTENTS",
+	[DESC] = "+DESC",
+	[REQUIRING] = "+REQUIRING",
+	[REQUIRED_BY] = "+REQUIRED_BY"
+};
+
+static int
+upkg_dump_description(struct upkg *pkg, const char *path) {
+	char desc_path[80];
+	FILE *f;
+	int n;
+
+	sprintf(desc_path, "%s/%s", path, upkg_info[DESC]);
+
+	if((f = fopen(desc_path, "r")) == NULL) {
+		return -1;
+	}
+
+	n = fread(pkg->description, 1, 80 * 25,f);
+
+	pkg->description[n] = '\0';
+
+	fclose(f);
+
+	return 0;
+}
+
+static int
+upkg_dump_packinglist(struct upkg *pkg, const char *path) {
+	char desc_path[80];
+	char packing_list[80 * 25];
+	FILE *f;
+	int n;
+
+	sprintf(desc_path, "%s/%s", path, upkg_info[CONTENTS]);
+
+	if((f = fopen(desc_path, "r")) == NULL) {
+		return -1;
+	}
+
+	n = fread(packing_list, 1, 80 * 25,f);
+
+	packing_list[n] = '\0';
+
+	if (upkg_plist_extract(pkg, packing_list) == -1) {
+		return -1;
+	}
+
+	fclose(f);
+
+	return 0;
+}
+
+static int
+upkg_dump_requiring(struct upkg *pkg __attribute__((unused)),
+		    const char *path __attribute__((unused))) {
+	/* XXX not yet implemented */
+
+	return 0;
+}
+
+static int
+upkg_dump_requiredby(struct upkg *pkg __attribute__((unused)),
+		     const char *path __attribute__((unused))) {
+	/* XXX not yet implemented */
+
+	return 0;
+}
+
+static inline int
+upkg_build_path(const char *name, char *path) {
+	const char *dbdir, *rootdir;
+
+	dbdir = upkg_config_get("UPKG_DBDIR");
+	rootdir = upkg_config_get("UPKG_ROOT");
+
+	sprintf(path, "%s%s/%s", rootdir, dbdir, name);
+
+	return 0;
+}
+
+int
+upkg_dump(struct upkg *pkg) {
+	char path[80];
+
+	/* extract package path */
+	upkg_build_path(pkg->name, path);
+
+	/* dump pkg info */
+	if (upkg_dump_description(pkg, path) == -1) {
+		return -1;
+	}
+	if (upkg_dump_packinglist(pkg, path) == -1) {
+		return -1;
+	}
+	if (upkg_dump_requiring(pkg, path) == -1) {
+		return -1;
+	}
+	if (upkg_dump_requiredby(pkg, path) == -1) {
+		return -1;
+	}
+
+	return 0;
+}
+
+void
+upkg_free(struct upkg *pkg) {
+	upkg_plist_free(pkg);
+}
+
+static int
+upkg_delete_special_file(struct upkg *pkg, char *name) {
+	const char *dbdir, *rootdir;
+	char path[80];
+
+	dbdir = upkg_config_get("UPKG_DBDIR");
+	rootdir = upkg_config_get("UPKG_ROOT");
+
+	sprintf(path, "%s%s/%s/%s", rootdir, dbdir, pkg->name, name);
+
+	return unlink(path);
+}
+
+static int
+upkg_delete_special_files(struct upkg *pkg) {
+	if (upkg_delete_special_file(pkg, upkg_info[DESC]) == -1) {
+		return -1;
+	}
+	if (upkg_delete_special_file(pkg, upkg_info[CONTENTS]) == -1) {
+		return -1;
+	}
+	return 0;
+}
+
+static int
+upkg_delete_dir(struct upkg *pkg) {
+	const char *dbdir, *rootdir;
+	char path[80];
+
+	dbdir = upkg_config_get("UPKG_DBDIR");
+	rootdir = upkg_config_get("UPKG_ROOT");
+
+	sprintf(path, "%s%s/%s", rootdir, dbdir, pkg->name);
+
+	return rmdir(path);
+}
+
+int
+upkg_delete(struct upkg *pkg) {
+	if (upkg_plist_delete_files(pkg) == -1) {
+		return -1;
+	}
+	if (upkg_delete_special_files(pkg) == -1) {
+		return -1;
+	}
+	if (upkg_delete_dir(pkg) == -1) {
+		return -1;
+	}
+
+	return 0;
+}

--- a/userspace/libupkg/upkg_config.c
+++ b/userspace/libupkg/upkg_config.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "libupkg/upkg_config.h"
+
+struct config_entry {
+	uint8_t type;
+	const char *key;
+	const char *def;
+};
+
+static struct config_entry config_entries[] = {
+	{
+		UPKG_STRING,
+		"UPKG_DBDIR",
+		"/var/db/upkg"
+	},
+	{
+		UPKG_STRING,
+		"UPKG_ROOT",
+		""
+	},
+	{
+		UPKG_STRING,
+		"UPKG_CACHE",
+		"/var/cache/upkg"
+	},
+	{
+		UPKG_STRING,
+		"UPKG_TMPDIR",
+		"/tmp"
+	},
+	{
+		UPKG_STRING,
+		"UPKG_LOCALPATH",
+		"/usr/share/upkg/ports"
+	},
+	{
+		UPKG_STRING,
+		"UPKG_PATH",
+		"8.8.8.8"
+	},
+	{
+		UPKG_NULL,
+		NULL,
+		NULL
+	}
+};
+
+static inline int
+upkg_entry_is_null(struct config_entry *entry) {
+	return (entry->type == UPKG_NULL &&
+		entry->key == NULL &&
+		entry->def == NULL);
+}
+
+static inline int
+upkg_is_entry(struct config_entry *entry, const char *key) {
+	return (strcmp(entry->key, key) == 0);
+}
+
+const char *
+upkg_config_get(const char *key) {
+	struct config_entry *entry;
+	const char *conf_def;
+
+	/* first, we look in the environment variables */
+	if ((conf_def = getenv(key)))
+		return conf_def;
+
+	/* otherwise, we check the default configurations */
+	for (entry = config_entries;
+	     !upkg_entry_is_null(entry) && !upkg_is_entry(entry, key);
+	     entry++)
+		;
+
+	return upkg_entry_is_null(entry) ? NULL : entry->def;
+}

--- a/userspace/libupkg/upkg_config.h
+++ b/userspace/libupkg/upkg_config.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#ifndef _UPKG_CONFIG_H_
+# define _UPKG_CONFIG_H_
+
+typedef enum {
+	UPKG_STRING = 0,
+	UPKG_BOOL,
+	UPKG_INT,
+	UPKG_NULL
+} upkg_type_t;
+
+extern const char *upkg_config_get(const char *key);
+
+#endif /*_UPKG_CONFIG_H_*/

--- a/userspace/libupkg/upkg_db.c
+++ b/userspace/libupkg/upkg_db.c
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+#define _POSIX_C_SOURCE 200809L
+#define __TOYOS__
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/file.h>
+#include <sys/types.h>
+
+#include <libupkg/upkg_config.h>
+#include <libupkg/upkg_db.h>
+#include <libupkg/libupkg.h>
+
+#define CLRSTR(X) (X[0] = '\0')
+
+static int fd_pkgdir = -1;
+
+//static struct upkg_db upkg_db = {};
+/* XXX: Do the list functions really need to be in this module? */
+
+int
+upkg_check(void) {
+	/* XXX: move to upkg.c */
+	return 1;
+}
+
+static void
+upkg_db_add_entry_at(struct upkg_repo_list *node, struct upkg *repo) {
+	struct upkg_repo_list *new_node =
+		malloc(sizeof(struct upkg_repo_list));
+	struct upkg_repo_list *next_node = node->next;
+
+	memcpy(&new_node->repo,repo,sizeof(struct upkg));
+
+	node->next = new_node;
+	new_node->next = next_node;
+}
+
+static int
+upkg_db_remove_entry_at(struct upkg_repo_list *node) {
+	struct upkg_repo_list *next_node = node->next;
+
+	if(!next_node)
+		return -1;
+
+	node->next = node->next->next;
+//	upkg_free(&next_node->repo);
+	free(next_node);
+
+	return 0;
+}
+
+static void
+upkg_db_remove_entries(struct upkg_repo_list *node) {
+	while(node->next != NULL)
+		upkg_db_remove_entry_at(node);
+}
+
+static int
+upkg_db_add_entry(struct upkg_db *db, struct upkg *repo) {
+	struct upkg_repo_list *repos_list = &db->repos;
+
+	/* to avoid a later sort, we try to keep an alphabetical order */
+	/* we let the first node empty as it is a sentinelle */
+	while(repos_list->next != NULL &&
+	      strcmp(repos_list->next->repo.name, repo->name) < 0)
+		repos_list = repos_list->next;
+
+	upkg_db_add_entry_at(repos_list, repo);
+
+	return 1;
+}
+
+struct upkg_db *
+upkg_db_get_empty(void) {
+	struct upkg_db *db = malloc(sizeof(struct upkg_db));
+
+	memset(&db->repos, 0, sizeof(struct upkg_repo_list));
+
+	return db;
+}
+
+int
+upkg_db_open(struct upkg_db *db) {
+	struct dirent *dirent;
+
+#ifdef __TOYOS__
+
+	// if (fd_pkgdir == -1) {
+	const char *dbdir, *rootdir;
+	char path[80];
+
+	dbdir = upkg_config_get("UPKG_DBDIR");
+	rootdir = upkg_config_get("UPKG_ROOT");
+
+	sprintf(path, "%s%s", rootdir, dbdir);
+    // fd_pkgdir = open(rootdir, O_RDWR);
+	// }
+
+	/* short ls */
+	DIR *dirp = opendir(path);
+
+#else
+
+	if (fd_pkgdir == -1) {
+		const char *dbdir, *rootdir;
+		char path[80];
+
+		dbdir = upkg_config_get("UPKG_DBDIR");
+		rootdir = upkg_config_get("UPKG_ROOT");
+
+		sprintf(path, "%s%s", rootdir, dbdir);
+		fd_pkgdir = open(rootdir, O_RDWR);
+	}
+
+	/* short ls */
+	DIR *dirp = fdopendir(fd_pkgdir);
+
+        rewinddir(dirp);
+#endif
+
+	if (!dirp) {
+		return -1;
+	}
+
+	struct upkg *current_repo = malloc(sizeof(struct upkg));
+
+	dirent = readdir(dirp);
+	while (dirent != NULL) {
+		/* XXX: put these names dynamic */
+		current_repo->internal = 0;
+		CLRSTR(current_repo->name);
+		CLRSTR(current_repo->path);
+		CLRSTR(current_repo->author);
+		CLRSTR(current_repo->version);
+		CLRSTR(current_repo->description);
+
+		if (dirent->d_name[0] != '.') {
+			size_t d_name_len = strlen(dirent->d_name);
+
+			memcpy(&current_repo->name, dirent->d_name,
+			       d_name_len);
+
+			current_repo->name[d_name_len] = '\0';
+
+			upkg_db_add_entry(db, current_repo);
+		}
+
+		dirent = readdir(dirp);
+	}
+	free(dirp);
+	free(current_repo);
+
+	return 0;
+}
+
+void
+upkg_db_release(struct upkg_db *db) {
+	upkg_db_remove_entries(&db->repos);
+	free(db);
+}
+
+int
+upkg_db_lock(void)
+{
+	const char *dbdir, *rootdir;
+	char path[80];
+
+	dbdir = upkg_config_get("UPKG_DBDIR");
+	rootdir = upkg_config_get("UPKG_ROOT");
+
+	sprintf(path, "%s%s", rootdir, dbdir);
+
+	fd_pkgdir = open(path, O_RDONLY);
+
+	if (flock(fd_pkgdir, LOCK_EX | LOCK_NB) == 0) {
+		return 0;
+	}
+
+	fprintf(stderr, "Package database is already locked... Wait...");
+
+	while(flock(fd_pkgdir, LOCK_EX | LOCK_NB)) ;
+
+	fprintf(stderr, "Done\n");
+
+	return 0;
+}
+
+int
+upkg_db_unlock(void)
+{
+	int r = flock(fd_pkgdir, LOCK_UN);
+
+	close(fd_pkgdir);
+
+	return r;
+}
+
+/* for debug purpose only */
+static void
+upkg_db_printall(struct upkg_db *db) {
+	struct upkg_repo_list *repos = &db->repos;
+
+	for(;repos->next != NULL; repos = repos->next)
+		printf("Found: %s\n", repos->next->repo.name);
+}
+
+static int
+upkg_db_exist(struct upkg_db *db, const char *name) {
+	struct upkg_repo_list *repos = &db->repos;
+
+	for(;repos->next != NULL; repos = repos->next)
+		if (strcmp(repos->next->repo.name, name) == 0)
+			return 1;
+
+	return 0;
+}
+
+static int
+upkg_db_get(struct upkg_db *db, struct upkg *upkg, const char *name) {
+	struct upkg_repo_list *repos = &db->repos;
+
+	for(;repos->next != NULL; repos = repos->next) {
+		if (strcmp(repos->next->repo.name, name) == 0) {
+			memcpy(upkg, &repos->next->repo, sizeof(struct upkg));
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static int
+upkg_db_delete(struct upkg_db *db, const char *name) {
+	struct upkg_repo_list *repos = &db->repos;
+
+	for(;repos->next != NULL; repos = repos->next) {
+		if (strcmp(repos->next->repo.name, name) == 0) {
+			if (upkg_db_remove_entry_at(repos) == -1)
+				return -1;
+			else
+				return 1;
+		}
+	}
+
+	return 0;
+}
+
+int
+upkg_db_request(upkg_db_request_t request, struct upkg_db *db,...)
+{
+	int r = 1;
+	va_list argp;
+	va_start(argp, db);
+
+	switch(request)
+	{
+	case UPKG_DB_PRINTALL:
+	{
+		upkg_db_printall(db);
+		break;
+	}
+	case UPKG_DB_GET:
+	{
+		struct upkg *pkg = va_arg(argp, void *);
+		const char *name = va_arg(argp, char *);
+		r = upkg_db_get(db, pkg, name);
+		break;
+	}
+	case UPKG_DB_EXIST:
+	{
+		r = upkg_db_exist(db, va_arg(argp, char *));
+		break;
+	}
+	case UPKG_DB_DELETE:
+	{
+		const char *name = va_arg(argp, char *);
+		r = upkg_db_delete(db, name);
+		break;
+	}}
+
+	va_end(argp);
+
+	return r;
+}
+
+/* 1 for yes, 0 for no */
+static inline int
+ask_yes_no (char *question, ...) {
+	/* XXX rewrite function without gotos */
+	/* XXX move to utils */
+	char input[3];
+	char *newline;
+
+try_again:
+	do {
+		va_list argp;
+		va_start(argp, question);
+		vfprintf(stderr, question, argp);
+		va_end(argp);
+
+	} while(!fgets(input, 3, stdin));
+
+	newline = strchr(input, '\n');
+	if (!newline) {
+		while (!newline && fgets(input, sizeof input, stdin))
+			newline = strchr(input, '\n');
+		goto try_again;
+	}
+	if (input[0] != 'y' && input[0] != 'n') {
+		goto try_again;
+	}
+
+	return input[0] == 'y';
+}
+
+int
+upkg_db_synchronize(struct upkg_db *db) {
+	struct upkg_db *disk_db = upkg_db_get_empty();
+	struct upkg_repo_list *disk_repos;
+	struct upkg_repo_list *repos;
+
+	if(upkg_db_open(disk_db) == -1) {
+		return -1;
+	}
+
+	disk_repos = &disk_db->repos;
+	repos = &db->repos;
+
+	while(repos->next != NULL || disk_repos->next != NULL) {
+		if (repos->next == NULL) {
+			/* deletions disk_repos->next->repo */
+			if(ask_yes_no("Do you really want to delete %s (y/n)? ",
+				      disk_repos->next->repo.name)) {
+				if (upkg_dump(&disk_repos->next->repo)
+				    == -1) {
+					return -1;
+				}
+				if (upkg_delete(&disk_repos->next->repo)
+				    == -1) {
+					printf("FAIL\n");
+					return -1;
+				}
+			}
+
+			if (disk_repos->next) {
+				disk_repos = disk_repos->next;
+			}
+			continue;
+		}
+		if (disk_repos->next == NULL) {
+			/* saving repos->next->repo */
+			if (repos->next) {
+				repos = repos->next;
+			}
+			continue;
+		}
+		int ord = strcmp(repos->next->repo.name,
+				 disk_repos->next->repo.name);
+		if (ord == 0) {
+			repos = repos->next;
+			disk_repos = disk_repos->next;
+		} else if (ord < 0) {
+			/* saving repos->next->repo */
+			repos = repos->next;
+		} else if (ord > 0) {
+			/* deletions disk_repos->next->repo */
+			if(ask_yes_no("Do you really want to delete %s (y/n)? ",
+				      disk_repos->next->repo.name)) {
+				if (upkg_dump(&disk_repos->next->repo)
+				    == -1) {
+					return -1;
+				}
+				if (upkg_delete(&disk_repos->next->repo)
+				    == -1) {
+					return -1;
+				}
+			}
+
+			disk_repos = disk_repos->next;
+		}
+	}
+
+	upkg_db_release(disk_db);
+
+	return 0;
+}

--- a/userspace/libupkg/upkg_db.h
+++ b/userspace/libupkg/upkg_db.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#ifndef _UPKG_DB_H_
+# define _UPKG_DB_H_
+
+#include "libupkg/libupkg.h"
+
+struct upkg_db {
+	struct upkg_repo_list repos;
+};
+
+typedef enum {
+	UPKG_DB_PRINTALL,
+	UPKG_DB_EXIST,
+	UPKG_DB_GET,
+	UPKG_DB_DELETE
+} upkg_db_request_t;
+
+int upkg_check(void);
+int upkg_db_open(struct upkg_db *db);
+int upkg_db_lock(void);
+int upkg_db_unlock(void);
+int upkg_db_request(upkg_db_request_t request, struct upkg_db *,...);
+void upkg_db_release(struct upkg_db *db);
+struct upkg_db *upkg_db_get_empty(void);
+int upkg_db_synchronize(struct upkg_db *db);
+
+#endif /*_UPKG_DB_H_*/

--- a/userspace/libupkg/upkg_plist.c
+++ b/userspace/libupkg/upkg_plist.c
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include <libupkg/libupkg.h>
+#include "upkg_plist.h"
+
+#define FLAG_SYMBOL '@'
+#define HOME_PATH_SYMBOL '~'
+#define ABSOLUTE_PATH_SYMBOL '/'
+
+static const char *upkg_plist_valid_flags[] = {
+	FLAG_NAME,
+	FLAG_AUTHOR,
+	FLAG_INTERNAL,
+	FLAG_VERSION,
+	NULL,
+};
+
+static int
+is_valid_flag(const char *flag) {
+	int i, len;
+	for (i = 0; upkg_plist_valid_flags[i] != NULL; ++i) {
+		len = strlen(upkg_plist_valid_flags[i]);
+		if (strncmp(upkg_plist_valid_flags[i], flag, len) == 0)
+			return 1;
+	}
+
+	return 0;
+}
+
+static void
+next_line(char **c) {
+	for (;**c != '\0' && **c != '\n';++*c)
+		;
+
+	if (**c == '\n')
+		++*c;
+}
+
+static int
+get_line_len(char *c) {
+	int i;
+
+	for (i = 0; *c != '\0' && *c!= '\n'; ++i, ++c)
+		;
+
+	return i;
+}
+
+static inline int
+is_a_flag(char *c) {
+	return *c == FLAG_SYMBOL;
+}
+
+static inline int
+is_a_path(char *c) {
+	/* relative path are forbidden */
+	return *c == HOME_PATH_SYMBOL || *c == ABSOLUTE_PATH_SYMBOL;
+}
+
+static inline int
+dump_flag_arg(char *target, char *line, char *flag) {
+	int flag_len, flag_arg_len;
+	char *flag_arg;
+
+	flag_len = strlen(flag);
+
+	if (strlen(line + flag_len + 1) < 2) {
+		return -1;
+	}
+
+	flag_arg = line + flag_len + 2;
+	flag_arg_len = strlen(flag_arg);
+
+	memcpy(target, flag_arg, flag_arg_len);
+
+	target[flag_arg_len] = '\0';
+
+	return 0;
+}
+
+int
+upkg_plist_extract_flag(struct upkg *pkg, char *it) {
+	/* XXX: flag name is a little bit silly because it's just the line */
+	char flag[80];
+	int line_len;
+
+	line_len = get_line_len(it);
+	memcpy(flag, it, line_len);
+	flag[line_len] = '\0';
+
+	if (!is_valid_flag(flag + 1)) {
+		return -1;
+	}
+
+	if (strncmp(FLAG_NAME, flag+1,strlen(FLAG_NAME)) == 0) {
+                # if 0
+		memset(pkg->name, 0, 80);
+		if (dump_flag_arg(pkg->name, flag, FLAG_NAME)
+		    == -1) {
+			return -1;
+		}
+		# endif
+	} else if (strncmp(FLAG_AUTHOR, flag+1,strlen(FLAG_AUTHOR)) == 0) {
+		if (dump_flag_arg(pkg->author, flag, FLAG_AUTHOR)
+		    == -1) {
+			return -1;
+		}
+	} else if (strncmp(FLAG_INTERNAL, flag+1,strlen(FLAG_INTERNAL))
+		   == 0) {
+		pkg->internal = 1;
+	} else if (strncmp(FLAG_VERSION, flag+1,strlen(FLAG_VERSION))
+		   == 0) {
+		if (dump_flag_arg(pkg->version, flag, FLAG_VERSION)
+		    == -1) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+static int
+upkg_add_plist_elt(struct upkg *pkg, char *path) {
+	struct upkg_plist_elt *elt;
+	struct upkg_plist_elt *it;
+
+	if ((elt = malloc(sizeof(struct upkg_plist_elt))) == NULL) {
+		return -1;
+	}
+	strncpy(elt->path, path, 80);
+	elt->next = NULL;
+	it = &pkg->plist;
+	while (it->next != NULL) {
+		it = it->next;
+	}
+	it->next = elt;
+
+	return 0;
+}
+
+void
+upkg_plist_show(struct upkg *pkg) {
+	struct upkg_plist_elt *it;
+
+	it = &pkg->plist;
+	while(it->next != NULL) {
+		printf("%s\n", it->next->path);
+		it = it->next;
+	}
+}
+
+void
+upkg_plist_free(struct upkg *pkg) {
+	struct upkg_plist_elt *it, *tmp;
+
+	it = &pkg->plist;
+	it = it->next;
+	while(it != NULL) {
+		tmp = it;
+		it = it->next;
+		free (tmp);
+	}
+}
+
+int
+upkg_plist_extract_path(struct upkg *pkg, char *it) {
+	char path[80];
+	int len;
+	len = get_line_len(it);
+	memcpy(path, it, len);
+	path[len] = '\0';
+
+	return upkg_add_plist_elt(pkg, path);
+}
+
+int
+upkg_plist_extract_line(struct upkg *pkg, char *it) {
+	if (is_a_flag(it)) {
+		return upkg_plist_extract_flag(pkg, it);
+	} else if (is_a_path(it)){
+		return upkg_plist_extract_path(pkg, it);
+	} else {
+		return -1;
+	}
+}
+
+int
+upkg_plist_extract(struct upkg *pkg, char *data) {
+	char *it;
+
+	/* for each line */
+	for (it = data; *it != '\0'; next_line(&it)) {
+		if (upkg_plist_extract_line(pkg, it) == -1) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
+int
+upkg_plist_delete_files(struct upkg *pkg) {
+	struct upkg_plist_elt *elt;
+	const char *rootdir;
+	char path[80];
+	int r = 0;
+
+	rootdir = upkg_config_get("UPKG_ROOT");
+
+	for (elt = pkg->plist.next; elt != NULL; elt = elt->next) {
+	        sprintf(path, "%s%s", rootdir, elt->path);
+		printf("unlink\n!");
+		if (unlink(path) == -1) {
+			r = -1;
+		}
+	}
+
+	return r;
+}

--- a/userspace/libupkg/upkg_plist.h
+++ b/userspace/libupkg/upkg_plist.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016 Fabien Siron <fabien.siron@epita.fr>
+ * All rights reserved.
+ *
+ * This program is Free Software, see COPYING for more info.
+ */
+
+#ifndef _UPKG_PLIST_H_
+# define _UPKG_PLIST_H_
+
+# include "libupkg/libupkg.h"
+
+# define FLAG_NAME "name"
+# define FLAG_AUTHOR "author"
+# define FLAG_INTERNAL "internal"
+# define FLAG_VERSION "version"
+
+int upkg_plist_extract_line(struct upkg *pkg, char *it);
+
+int upkg_plist_extract(struct upkg *pkg, char *data);
+
+void upkg_plist_show(struct upkg *pkg);
+void upkg_plist_free(struct upkg *pkg);
+int upkg_plist_delete_files(struct upkg *pkg);
+
+#endif /* !_UPKG_PLIST_H_*/

--- a/util/auto-dep.py
+++ b/util/auto-dep.py
@@ -44,6 +44,10 @@ class Classifier(object):
         '"lib/libzip.h"':      (None, 'userspace/lib/libzip.o',      ['"lib/ioapi.h"']),
         '"lib/libunzip.h"':    (None, 'userspace/lib/libunzip.o',    ['"lib/ioapi.h"']),
         '"lib/libtar.h"':      (None, 'userspace/lib/libtar.o',     []),
+        '"libupkg/upkg_plist.h"': (None, 'userspace/libupkg/upkg_plist.o', []),
+        '"libupkg/upkg_db.h"': (None, 'userspace/libupkg/upkg_db.o', []),
+        '"libupkg/upkg_config.h"': (None, 'userspace/libupkg/upkg_config.o', []),
+        '"libupkg/libupkg.h"': (None, 'userspace/libupkg/upkg.o', []),
         # Yutani Libraries
         '"lib/yutani.h"':      (None, 'userspace/lib/yutani.o',      ['"lib/list.h"', '"lib/pex.h"', '"lib/graphics.h"', '"lib/hashmap.h"']),
         '"lib/decorations.h"': (None, 'userspace/lib/decorations.o', ['"lib/shmemfonts.h"', '"lib/graphics.h"', '"lib/yutani.h"']),

--- a/util/create-image.sh
+++ b/util/create-image.sh
@@ -16,6 +16,7 @@ fi
 DISK=toyos-disk.img
 SRCDIR=$1
 BOOT=./boot
+UPKG=$SRCDIR/upkg
 SIZE=1G
 
 echo "Please select a disk size."
@@ -72,6 +73,12 @@ cp -r $SRCDIR/hdd/* /mnt/
 echo "Installing boot files."
 mkdir -p  /mnt/boot
 cp -r $BOOT/* /mnt/boot/
+
+echo "Installing var/db/upkg"
+mkdir -p /mnt/var/db/upkg
+cp -r $UPKG/* /mnt/var/db/upkg
+
+touch /mnt/HELLO
 
 echo "Installing kernel."
 cp -r $SRCDIR/toyos-kernel /mnt/boot/


### PR DESCRIPTION
There are probably some stuff to change. I am currently porting pkg_delete and I begin pkg_add.

Usage:
$ export UPKG_DBDIR=/usr/pkg
$ pkg_info -Ac

Note: the upkg dbdir should be in /var/db/upkg or /var/db/pkg but it seems that they are some bugs in the hdd generation.